### PR TITLE
Adding AirTurn support for anchor movement

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,15 @@
 						    <button class="btn btn-primary active">Off</button>
 						</div>
 					</div>
+					<div class='col-md-2 col-sm-2'>
+						<small>
+							<label for="airturn">AirTurn Anchors</label>
+						</small><br>
+						<div id="airturn" class="btn-group  btn-group-sm btn-toggle"> 
+						    <button class="btn btn-default">On</button>
+						    <button class="btn btn-primary active">Off</button>
+						</div>
+					</div>
 					<!--
  					<div class='col-md-1 col-sm-1'>
 						<small>

--- a/js/editor.js
+++ b/js/editor.js
@@ -529,7 +529,7 @@ var debug = false;
         else if (typeof tinymce !== "undefined")
             htmldata = tinymce.get("prompt").getContent();
         // Define possible values
-        var primary, secondary, style, focusArea, speed, acceleration, fontSize, timer, voice;
+        var primary, secondary, style, focusArea, speed, acceleration, fontSize, timer, airturn, voice;
         // Get form values
         if (override!==undefined && typeof override==='string' || override instanceof String)
             override = JSON.parse(override);
@@ -574,12 +574,20 @@ var debug = false;
             else
                 timer = false;
         }
+        if (override!==undefined && override.airturn!==undefined)
+            airturn = override.airturn;
+        else {
+            if ( document.getElementById("airturn").children[0].classList.contains("btn-primary") )
+                airturn = true;
+            else
+                airturn = false;
+        }
         if (override!==undefined && override.voice!==undefined)
             voice = override.voice;
         else
             voice = false;
         // Merge all settings into one.
-        var settings = '{ "data": {"primary":'+primary+',"secondary":'+secondary+',"prompterStyle":'+style+',"focusMode":'+focusArea+',"speed":'+speed+',"acceleration":'+acceleration+',"fontSize":'+fontSize+',"promptWidth":'+promptWidth+',"timer":'+timer+',"voice":'+voice+'}}',
+        var settings = '{ "data": {"primary":'+primary+',"secondary":'+secondary+',"prompterStyle":'+style+',"focusMode":'+focusArea+',"speed":'+speed+',"acceleration":'+acceleration+',"fontSize":'+fontSize+',"promptWidth":'+promptWidth+',"timer":'+timer+',"airturn":'+airturn+',"voice":'+voice+'}}',
         session = '{ "html":"' + encodeURIComponent(htmldata) + '" }';
 
         // Store data locally for prompter to use
@@ -914,17 +922,19 @@ var debug = false;
                 break;
                 case 34 :
                 case "PageDown" :
+                var cmd = (settings.data.airturn) ? command.nextAnchor : command.fastForward;
                 listener({
                     data: {
-                        request: command.fastForward
+                        request: cmd
                     }
                 });
                 break;
                 case 33 :
                 case "PageUp" :
+                var cmd = (settings.data.airturn) ? command.previousAnchor : command.rewind;
                 listener({
                     data: {
-                        request: command.rewind
+                        request: cmd
                     }
                 });
                 break;

--- a/js/teleprompter.js
+++ b/js/teleprompter.js
@@ -1212,11 +1212,13 @@ https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/onversionchange
                 break;
             case 34 :
             case "PageDown" :
-                editor.postMessage( {'request':command.fastForward}, getDomain() );
+                var cmd = (settings.data.airturn) ? command.nextAnchor : command.fastForward;
+                editor.postMessage( {'request':cmd}, getDomain() );
                 break;
             case 33 :
             case "PageUp" :
-                editor.postMessage( {'request':command.rewind}, getDomain() );
+                var cmd = (settings.data.airturn) ? command.previousAnchor : command.rewind;
+                editor.postMessage( {'request':cmd}, getDomain() );
                 break;
             default: // Move to anchor.
                 // If key is not a string


### PR DESCRIPTION
I'm curious if you would be interested in this feature.  I use the AirTurn Duo foot pedals when using a teleprompter (e.g. https://www.airturn.com/products/airturn-duo-200) but I prefer anchor navigation much more than timing the scroll rate.  Unfortunately, the AirTurn can't emulate Home / End keys so I added an option to enable PageUp / Down anchor navigation in the settings.  Let me know if you are interested in this or if there is a better way to approach the feature.